### PR TITLE
Fix build on linux.

### DIFF
--- a/phoenix-2.0/Defines.mk
+++ b/phoenix-2.0/Defines.mk
@@ -39,7 +39,7 @@ OS = -D_LINUX_
 CC = gcc
 #DEBUG = -g
 CFLAGS = -Wall $(OS) $(DEBUG) -O3
-LIBS = -lpthread
+LIBS = -pthread
 endif
 
 ifeq ($(OSTYPE),SunOS)


### PR DESCRIPTION
Adds lib directory to git (otherwise libphoenix.a becomes lib instead of putting
it in directory lib). Also fix pthread include flag in Defines.mk to avoid
unresolved linker errors.