### PR TITLE
Fix heap buffer overflow for `string_match` benchmark when `NO_MMAP` flag is used.

### DIFF
--- a/phoenix-2.0/tests/string_match/string_match.c
+++ b/phoenix-2.0/tests/string_match/string_match.c
@@ -256,7 +256,7 @@ int main(int argc, char *argv[]) {
 #else
     int ret;
 
-    fdata_keys = (char *)malloc (finfo_keys.st_size);
+    fdata_keys = (char *)malloc (finfo_keys.st_size + 1);
     CHECK_ERROR (fdata_keys == NULL);
 
     ret = read (fd_keys, fdata_keys, finfo_keys.st_size);


### PR DESCRIPTION
## What is this PR doing:
Fixes #9 
This PR adapts the buffer allocation for the `string_match` benchmark when the `NO_MMAP` flag is set to eliminate the heap buffer overflow detected by `ASan`.

## How to test this PR:
#### Compile the benchmarks with a patch that enables the `NO_MMAP` flag and `AddressSanitizer` (`ASan`):
```
$ git clone https://github.com/kozyraki/phoenix.git

$ git fetch origin pull/10/head:sm_overflow_fix

$ git switch sm_overflow_fix

$ cd phoenix/phoenix-2.0/

$ echo 'diff --git a/phoenix-2.0/tests/string_match/Makefile b/phoenix-2.0/tests/string_match/Makefile
index be7d94b..310b965 100644
--- a/phoenix-2.0/tests/string_match/Makefile
+++ b/phoenix-2.0/tests/string_match/Makefile
@@ -46,16 +46,16 @@ default: all
 all: $(PROGS)
 
 string_match: $(STR_MATCH_OBJS) $(LIB_DEP)
-    $(CC) $(CFLAGS) -o $@ $(STR_MATCH_OBJS) $(LIBS)
+    $(CC) $(CFLAGS) -o $@ $(STR_MATCH_OBJS) $(LIBS) -fsanitize=address
 
 string_match-seq: $(STR_MATCH_SEQ_OBJS)
-    $(CC) $(CFLAGS) -o $@ $(STR_MATCH_SEQ_OBJS) $(LIBS)
+    $(CC) $(CFLAGS) -o $@ $(STR_MATCH_SEQ_OBJS) $(LIBS) -fsanitize=address
 
 string_match-pthread: $(STR_MATCH_PTHREAD_OBJS)
-    $(CC) $(CFLAGS) -o $@ $(STR_MATCH_PTHREAD_OBJS) $(LIBS)
+    $(CC) $(CFLAGS) -o $@ $(STR_MATCH_PTHREAD_OBJS) $(LIBS) -fsanitize=address
 
 %.o: %.c
-    $(CC) $(CFLAGS) -c $< -o $@ -I$(HOME)/$(INC_DIR)
+    $(CC) $(CFLAGS) -c $< -o $@ -I$(HOME)/$(INC_DIR) -DNO_MMAP=1 -fsanitize=address
 
 clean:
     rm -f $(PROGS) $(STR_MATCH_OBJS) $(STR_MATCH_SEQ_OBJS) $(STR_MATCH_PTHREAD_OBJS)' > sm_overflow.patch

$ git apply sm_overflow.patch

$ make
```

#### Retrieve the inputs for the `string_match` benchmark:
```
$ cd tests/string_match

$ wget http://csl.stanford.edu/~christos/data/string_match.tar.gz

$ tar -xvf string_match.tar.gz
```

#### Run the `string_match`benchmark and observe the output of `ASan`:
```
$ ./string_match string_match_datafiles/key_file_50MB.txt
```
With the change included in this PR, `ASan` **does not** report any heap buffer overflow error.

### Tested on:
OS: `Ubuntu 22.04.4 LTS`
Kernel: `6.2.0-39-generic`
gcc: `11.4.0`